### PR TITLE
Fix possibly improper map list

### DIFF
--- a/index.php
+++ b/index.php
@@ -128,7 +128,7 @@ if (API_KEY != false) {SteamID::SetSteamAPIKey(API_KEY);}
                     <select name="map" class="form-control" required>
                         <option value="" selected="selected">None</option>
                         <?php
-                        $result = mysqli_query($connection, 'SELECT DISTINCT map FROM '.MYSQL_PREFIX.'mapzones ORDER BY map ASC;');
+                        $result = mysqli_query($connection, 'SELECT DISTINCT map FROM '.MYSQL_PREFIX.'playertimes ORDER BY map ASC;');
 
                         if ($result->num_rows > 0) {
                             while ($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The drop-down menu with the map list could possibly be "incorrect". As it currently stands, this list is grabbed by a query which gets every distinct map name found in the mapzones table, and puts them in alphabetical order.

This is problematic for 2 reasons:

- Automatically zoned maps (trigger starts/ends) do not get inserted to the mapzones table, meaning you will need to manipulate the URL to get to these maps and see their stats.
- It is more likely that servers will have "extra" zoned maps (maps that are probably not even on server), and lead to blank stats pages.

This solves both above issues by changing the query to the playertimes table. This way, only maps that have completions on the map/bonus get listed. Hat tip to @mbhound for identifying the issue!